### PR TITLE
Update upper bounds for dependencies

### DIFF
--- a/bloomfilter-redis.cabal
+++ b/bloomfilter-redis.cabal
@@ -39,12 +39,12 @@ library
                    , BangPatterns
                    , Safe
                    , CPP
-  build-depends:     base       >= 4.7 && < 4.13
+  build-depends:     base       >= 4.7 && < 4.14
                    , bytestring >= 0.9 && < 0.11
                    , binary     >= 0.7 && < 0.9
                    , hashable   >= 1.2 && < 1.4
                    , hedis      >= 0.5 && < 0.13
-                   , arithmoi   >= 0.3 && < 0.10
+                   , arithmoi   >= 0.3 && < 0.11
   hs-source-dirs:    src
 
 test-suite test-bloomfilter-redis
@@ -61,7 +61,7 @@ test-suite test-bloomfilter-redis
                    , tasty            >= 0.8 && < 1.3
                    , tasty-rerun      >= 1.1 && < 1.2
                    , tasty-quickcheck >= 0.8 && < 0.11
-                   , QuickCheck       >= 2.8 && < 2.13
+                   , QuickCheck       >= 2.8 && < 2.14
                    , tasty-hunit      >= 0.9 && < 0.11
 
 benchmark bench-bloomfilter-redis


### PR DESCRIPTION
This makes `bloomfilter-redis` compatible with the latest ecosystem.